### PR TITLE
Re-write merge-compatible-upgrades for github-script@v5

### DIFF
--- a/.github/workflows/scripts/merge-compatible-upgrades.js
+++ b/.github/workflows/scripts/merge-compatible-upgrades.js
@@ -1,20 +1,25 @@
 module.exports = main;
 
 async function main({ context, github }) {
-  let owner = context.payload.repository.owner.login;
-  let repo = context.payload.repository.name;
+  const owner = context.payload.repository.owner.login;
+  const repo = context.payload.repository.name;
 
-  if (!context.payload.workflow_run.pull_requests.length) {
+  const run_id = context.runId;
+  const workflow_run = (
+    await github.rest.actions.getWorkflowRun({ owner, repo, run_id })
+  ).data;
+
+  if (!workflow_run.pull_requests.length) {
     return;
   }
 
-  if (context.payload.workflow_run.pull_requests.length > 1) {
+  if (workflow_run.pull_requests.length > 1) {
     throw new Error("Completed Workflow ran on multiple pull requests");
   }
 
-  let pull_number = context.payload.workflow_run.pull_requests[0].number;
+  const pull_number = workflow_run.pull_requests[0].number;
 
-  await github.pulls.merge({
+  await github.rest.pulls.merge({
     owner,
     repo,
     pull_number,


### PR DESCRIPTION
Dependabot automatically upgraded to actions/github-script@v5, which contained breaking changes. The changes were not automatically detected since the breaking changes were inside a mock. Preventing this may be possible, but it is not obvious how since they are not npm packages. Maybe by cloning the repo? A problem for another day.